### PR TITLE
to make the methods within_*_has_many more universal

### DIFF
--- a/lib/capybara/active_admin/finders/form.rb
+++ b/lib/capybara/active_admin/finders/form.rb
@@ -26,9 +26,7 @@ module Capybara
         # @yield within container have_many by passed association_name
         def within_has_many(association_name)
           selector = has_many_container_selector(association_name)
-          fieldset = find(selector)
-
-          within(fieldset) { yield }
+          within(selector) { yield }
         end
 
         # @yield within filters container.

--- a/lib/capybara/active_admin/finders/form.rb
+++ b/lib/capybara/active_admin/finders/form.rb
@@ -22,6 +22,15 @@ module Capybara
           within(fieldset) { yield }
         end
 
+        # @param association_name [String]
+        # @yield within container have_many by passed association_name
+        def within_has_many(association_name)
+          selector = has_many_container_selector(association_name)
+          fieldset = find(selector)
+
+          within(fieldset) { yield }
+        end
+
         # @yield within filters container.
         def within_filters
           selector = filter_form_selector

--- a/lib/capybara/active_admin/selectors/form.rb
+++ b/lib/capybara/active_admin/selectors/form.rb
@@ -35,6 +35,12 @@ module Capybara
           "div.has_many_container.#{association_name} > fieldset.inputs.has_many_fields"
         end
 
+        # @param association_name [String]
+        # @return [String] .has_many_container selector.
+        def has_many_container_selector(association_name)
+          ".has_many_container.#{association_name}"
+        end
+
         # @param text [String, nil] submit button text.
         # @return [String] selector.
         def form_submit_selector(text = nil)


### PR DESCRIPTION
In this PR I suggestion couple helpers that provides more flexable acces to form has_many
1. In some moments, we have not yet rendered the  `fieldset` that should contains in .has_many_container and we do not have access to it.
2.  In some cases we have `li` dom element instead `div` which is responsible as a container has many