### PR TITLE
change window size in development env when we use cuprite driver

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,7 +44,7 @@ Capybara.register_driver :cuprite_headless do |app|
 end
 
 Capybara.register_driver :cuprite do |app|
-  Capybara::Cuprite::Driver.new(app, cuprite_opts.merge(headless: false))
+  Capybara::Cuprite::Driver.new(app, cuprite_opts.merge(headless: false, window_size: [1440, 900]))
 end
 
 Capybara.javascript_driver = ENV['JS_DRIVER'].presence&.to_sym || :cuprite_headless


### PR DESCRIPTION
change window size in system tests to 1440x900 for non-headless because its max resolution for macbook pro 15 retina